### PR TITLE
Add simple landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hedy Lamarr Project</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="hero">
+    <nav class="navbar">
+      <h1 class="logo">Hedy Lamarr</h1>
+      <ul class="nav-links">
+        <li><a href="#about">About</a></li>
+        <li><a href="#works">Works</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+    <div class="hero-content">
+      <h2>Celebrating Innovation and Glamour</h2>
+      <p>A digital humanities project exploring the life and legacy of Hedy Lamarr.</p>
+      <a href="#about" class="btn">Learn More</a>
+    </div>
+  </header>
+
+  <section id="about" class="section">
+    <div class="container">
+      <h2>About Hedy Lamarr</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vel arcu eget quam posuere dictum.</p>
+      <p>Nulla facilisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+    </div>
+  </section>
+
+  <section id="works" class="section bg-light">
+    <div class="container">
+      <h2>Selected Works</h2>
+      <ul class="works-list">
+        <li>Algiers (1938)</li>
+        <li>Samson and Delilah (1949)</li>
+        <li>Secret Communication System (US Patent 2,292,387)</li>
+        <li>Frequency Hopping Spread Spectrum</li>
+      </ul>
+    </div>
+  </section>
+
+  <section id="contact" class="section">
+    <div class="container">
+      <h2>Contact Us</h2>
+      <form id="contact-form">
+        <input type="text" id="name" placeholder="Your Name" required>
+        <input type="email" id="email" placeholder="Your Email" required>
+        <textarea id="message" placeholder="Message" required></textarea>
+        <button type="submit" class="btn">Send</button>
+      </form>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <p>&copy; 2025 Hedy Lamarr Project</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+// Simple form handler
+const form = document.getElementById('contact-form');
+if (form) {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    alert('Thank you for your message!');
+    form.reset();
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,84 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+.hero {
+  background: linear-gradient(135deg, #1e90ff, #e63946);
+  color: #fff;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+}
+
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.hero-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 20px;
+  background: rgba(0,0,0,0.5);
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 10px 20px;
+  background: #e63946;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.section {
+  padding: 60px 20px;
+}
+
+.bg-light {
+  background: #f4f4f4;
+}
+
+.container {
+  max-width: 800px;
+  margin: auto;
+}
+
+.footer {
+  text-align: center;
+  padding: 20px;
+  background: #222;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- create a single page landing site with HTML/CSS/JS
- basic sections for hero, about, works and contact
- include minimal JavaScript form handler

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68575fe95d1083229355c5d207261884